### PR TITLE
Fixed SPI config for ADC input. Also Fixed iio Dev number.

### DIFF
--- a/wiringx86.py
+++ b/wiringx86.py
@@ -841,11 +841,9 @@ class GPIOEdison(GPIOBase):
         self.pwm_periods = {}
         for pin in self.PWM_MAPPING.keys():
             self.pwm_periods[pin] = self.PWM_DEFAULT_PERIOD
-        # Set SPI pins into a valid state so ADC will work.
-	self.pinMode(10,'in')
-	self.pinMode(11,'in')
-	self.pinMode(12,'in')
-	self.pinMode(13,'in')
+        # Set all pins into a safe state at startup.
+        for i in range(0,20):
+	    self.pinMode(i, INPUT)
 
     def _set_pwm_period(self, pin, period):
         self.pwm_periods[pin] = period

--- a/wiringx86.py
+++ b/wiringx86.py
@@ -272,14 +272,14 @@ class GPIOBase(object):
             f = open('/sys/class/gpio/gpio%d/value' % linux_pin, 'r+')
             self.gpio_handlers[linux_pin] = f
         except:
-            print "Failed opening value file for pin %d" % linux_pin
+            print "Failed opening digital value file for pin %d" % linux_pin
 
     def _open_analog_handler(self, linux_pin, adc):
         try:
-            f = open('/sys/bus/iio/devices/iio:device0/in_voltage%d_raw' % adc, 'r+')
+            f = open('/sys/bus/iio/devices/iio:device1/in_voltage%d_raw' % adc, 'r+')
             self.gpio_handlers[linux_pin] = f
         except:
-            print "Failed opening value file for pin %d" % linux_pin
+            print "Failed opening analog value file for pin %d" % linux_pin
 
     def _write_value(self, linux_pin, state):
         value = 1
@@ -838,6 +838,11 @@ class GPIOEdison(GPIOBase):
         self.pwm_periods = {}
         for pin in self.PWM_MAPPING.keys():
             self.pwm_periods[pin] = self.PWM_DEFAULT_PERIOD
+        # Set SPI pins into a valid state so ADC will work.
+	self.pinMode(10,'in')
+	self.pinMode(11,'in')
+	self.pinMode(12,'in')
+	self.pinMode(13,'in')
 
     def _set_pwm_period(self, pin, period):
         self.pwm_periods[pin] = period

--- a/wiringx86.py
+++ b/wiringx86.py
@@ -276,7 +276,7 @@ class GPIOBase(object):
 
     def _open_analog_handler(self, linux_pin, adc):
         try:
-            f = open('/sys/bus/iio/devices/iio:device1/in_voltage%d_raw' % adc, 'r+')
+            f = open('/sys/bus/iio/devices/iio:device%d/in_voltage%d_raw' % (self.adc_iio_device, adc), 'r+')
             self.gpio_handlers[linux_pin] = f
         except:
             print "Failed opening analog value file for pin %d" % linux_pin
@@ -453,6 +453,7 @@ class GPIOGalileo(GPIOBase):
     PWM_DEFAULT_PERIOD = 5000000
 
     def __init__(self, **kwargs):
+        self.adc_iio_device = 0
         super(GPIOGalileo, self).__init__(**kwargs)
         self.pwm_periods = {}
         for pwm in self.PWM_MAPPING.keys():
@@ -643,6 +644,7 @@ class GPIOGalileoGen2(GPIOBase):
     PWM_DEFAULT_PERIOD = 5000000
 
     def __init__(self, **kwargs):
+        self.adc_iio_device = 0
         super(GPIOGalileoGen2, self).__init__(**kwargs)
         self.pwm_period = self.PWM_DEFAULT_PERIOD
         self.is_pwm_period_set = False
@@ -834,6 +836,7 @@ class GPIOEdison(GPIOBase):
 
     def __init__(self, **kwargs):
         self.pinmux = 214
+        self.adc_iio_device = 1
         super(GPIOEdison, self).__init__(**kwargs)
         self.pwm_periods = {}
         for pin in self.PWM_MAPPING.keys():


### PR DESCRIPTION
SPI comes up in an odd configuration and needs to be set into a valid config before you can read from the ADC, which is on the SPI bus. So set Pins 10-13 to input. These can be overridden later by the python code, but we need at least a good initial config. 

Also changed the iio device number from 0 to 1, as on the Arduino board it's now 1 fro the ADC iii driver. 

Signed-off-by: David Hunt dave@davidhunt.ie
